### PR TITLE
Add Math Object Properties Table

### DIFF
--- a/e.cyc
+++ b/e.cyc
@@ -1,6 +1,6 @@
 @chapter "E"
 
-@specimen "e"
+@specimen "E"
 
     The letter e or E can indicate the exponent part of a number literal.
 

--- a/m.cyc
+++ b/m.cyc
@@ -121,15 +121,16 @@
 
     The Math primordial object is the container for these numeric properties:
 
-    @list {
-    @link(E Math number)
-    @link(LN10 Math number)
-    @link(LN2 Math number)
-    @link(LOG10E Math number)
-    @link(LOG2E Math number)
-    @link(PI Math number)
-    @link(SQRT1_2 Math number)
-    @link(SQRT2 Math number)
+    @table {
+    @!property@|@!description@|@!numeric value
+    @_@link(E)@|approximate value of e(Eulers number)@|2.718281828459045
+    @_@link(LN10)@|natural logarithm of 10@|2.302585092994046
+    @_@link(LN2)@|natural logarithm of 2@|0.6931471805599453
+    @_@link(LOG10E)@|base 10 logarithm of e@|0.4342944819032518
+    @_@link(LOG2E)@|base 2 logarithm of e@|1.4426950408889634
+    @_@link(PI)@|approximate value of π(pi) @|3.141592653589793
+    @_@link(SQRT1_2)@|Square root of 1/2(.5)@|0.7071067811865476
+    @_@link(SQRT2)@|Square root of 2@|1.4142135623730951
     }
 
 @specimen "max"

--- a/p.cyc
+++ b/p.cyc
@@ -53,7 +53,7 @@
 
     Blah.
 
-@specimen "pi"
+@specimen "PI"
 
     @article(@t(PI) @link(Math number) @aka(pi))
 

--- a/special.cyc
+++ b/special.cyc
@@ -233,7 +233,20 @@ function bitwise_and(left, right) {
 
 @article(@t(&&) @link(infix operator) @aka(and))
 
-Blah.
+The @t(&&) infix operator performs a logical AND operation between two operands, 
+evaluated as a @link(boolean). The @t(&&) operator produces @link(true)if both operands are @link(truthy), 
+and @link(false) if either operand is @link(falsy). If the first operand is @link(falsy), the second operand is skipped and the @t(&&) operator evaluates to @link(false).  
+
+Examples:
+
+@begin(program)
+true  &&  true           // true
+true  &&  false          // false
+false &&  true           // false
+false &&  false          // false
+true  &&  'hello'        // "hello"
+   1  &&  3              // 3
+@end(program)
 
 @article(@t(&=) @link(assignment infix operator) @aka(bitwise and))
 


### PR DESCRIPTION
Makes it convenient to see what the Math Object properties result in, instead of clicking each link. The links are still present. 