### PR TITLE
Add ECMA Version history and A Simple Navigation In Introduction

### DIFF
--- a/e.cyc
+++ b/e.cyc
@@ -153,9 +153,27 @@
 
 @specimen "ES2015 @aka(ES6)"
 
-    Blah. See @link(ES6)
+    ECMAScript Programming Language Standard, Sixth Edition [2015].
 
-    ECMAScript Programming Language Standard, Third Edition [1999].
+@specimen "ES2016 @aka(ES7)"
+
+    ECMAScript Programming Language Standard, Seventh Edition [2016].
+
+@specimen "ES2017 @aka(ES8)"
+
+    ECMAScript Programming Language Standard, Eighth Edition [2017].
+
+@specimen "ES2018 @aka(ES9)"
+
+    ECMAScript Programming Language Standard, Ninth Edition [2018].
+
+@specimen "ES1"
+
+    ECMAScript Programming Language Standard, First Edition [1997].
+
+@specimen "ES2" 
+
+    ECMAScript Programming Language Standard, Second Edition [1998].
 
 @specimen "ES3"
 
@@ -163,15 +181,15 @@
 
 @specimen "ES4"
 
-    There is no @link(es4).
+    There is no @link(es4). The specification was abandoned. 
 
 @specimen "ES5"
 
     ECMAScript Programming Language Standard, Fifth Edition [2009].
 
-@specimen "ES6"
+@specimen "ES6 @aka(ECMAScript 2015)"
 
-    ECMAScript Programming Language Standard, Sixth Edition [2015].
+    An earlier and common name for ECMAScript Programming Language Standard, Sixth Edition [2015]. To avoid confusion and to have yearly releases it was officially renamed to @link(ES2015).
 
 @specimen "escapement"
 

--- a/g.cyc
+++ b/g.cyc
@@ -1,8 +1,5 @@
 @chapter "G"
 
-@specimen "g"
-
-    @article "@t(g) @link(regexp flag)"
 
 @specimen "get"
 

--- a/i.cyc
+++ b/i.cyc
@@ -1,9 +1,5 @@
 @chapter "I"
 
-@specimen(i)
-
-    @article(@t(i) @link(regexp flag))
-
 @specimen "identifier"
 
     See @link(name).

--- a/introduction.cyc
+++ b/introduction.cyc
@@ -1,12 +1,23 @@
 @chapter "Introduction"
 
-@specimen "History"
-
-@specimen "Format"
-
 The language described in this book is @link "es6".
 The standard, which is designated as ECMA-262, may be found at
-@url<http://www.ecma-international.org/publications/standards/ECMA-262.htm>.
+@url<https://www.ecma-international.org/publications/standards/Ecma-262.htm>.
+
+Version history:
+
+@table {
+@!version@|@!release
+@_@link(ES1)@|1997
+@_@link(ES2)@|1998
+@_@link(ES3)@|1999
+@_@link(ES4)@|N/A
+@_@link(ES5)@|2009
+@_@link(ES6)@|2015
+@_@link(ES2016)@|2016
+@_@link(ES2017)@|2017
+@_@link(ES2018)@|2018
+}
 
 Because of trademark problems, the standard for the @link(JavaScript) language
 is called @link(ECMAScript). JavaScript is a trademark of Oracle Corporation.

--- a/introduction.cyc
+++ b/introduction.cyc
@@ -1,8 +1,12 @@
 @chapter "Introduction"
 
+@specimen "History"
+
+@specimen "Format"
+
 The language described in this book is @link "es6".
 The standard, which is designated as ECMA-262, may be found at
-@url<http://www.ecma-international.org/publications/standards/ECMA-262.HTM>.
+@url<http://www.ecma-international.org/publications/standards/ECMA-262.htm>.
 
 Because of trademark problems, the standard for the @link(JavaScript) language
 is called @link(ECMAScript). JavaScript is a trademark of Oracle Corporation.

--- a/introduction.cyc
+++ b/introduction.cyc
@@ -7,7 +7,7 @@ The standard, which is designated as ECMA-262, may be found at
 Version history:
 
 @table {
-@!version@|@!release
+@!version@|@!released
 @_@link(ES1)@|1997
 @_@link(ES2)@|1998
 @_@link(ES3)@|1999
@@ -20,7 +20,7 @@ Version history:
 }
 
 Because of trademark problems, the standard for the @link(JavaScript) language
-is called @link(ECMAScript). JavaScript is a trademark of Oracle Corporation.
+is called @link(ECMAScript). JavaScript is a trademark of @link(Oracle Corporation).
 
 @program <"use strict";>
 
@@ -30,6 +30,10 @@ specimens, where a specimen is an element of syntax or a concept. The specimens
 are ordered alphabetically. A specimen marked with @reserved@ indicates that
 the word is reserved and cannot be used as a parameter or variable name.
 The special characters chapter is sorted according to the @link(ASCII) sequence.
+
+@table{
+@!@link(Special Characters)@|@!@link(A)@|@!@link(B)@|@!@link(C)@|@!@link(D)@|@!@link(E)@|@!@link(F)@|@!@link(G)@|@!@link(H)@|@!@link(I)@|@!@link(J)@|@!@link(K)@|@!@link(L)@|@!@link(M)@|@!@link(N)@|@!@link(O)@|@!@link(P)@|@!@link(Q)@|@!@link(R)@|@!@link(S)@|@!@link(T)@|@!@link(U)@|@!@link(V)@|@!@link(W)@|@!@link(X)@|@!@link(Y)@|@!@link(Z)
+}
 
 Under each specimen there will be one or more articles that explain, expand,
 or are related to the specimen. An article may be composed of one or more sections.

--- a/m.cyc
+++ b/m.cyc
@@ -1,8 +1,5 @@
 @chapter "M"
 
-@specimen "m"
-
-    @article "@t(m) @link(regexp flag)"
 
 @specimen "map"
 
@@ -128,7 +125,7 @@
     @_@link(LN2)@|natural logarithm of 2@|0.6931471805599453
     @_@link(LOG10E)@|base 10 logarithm of e@|0.4342944819032518
     @_@link(LOG2E)@|base 2 logarithm of e@|1.4426950408889634
-    @_@link(PI)@|approximate value of π(pi) @|3.141592653589793
+    @_@link(PI)@|approximate value of π @|3.141592653589793
     @_@link(SQRT1_2)@|Square root of 1/2(.5)@|0.7071067811865476
     @_@link(SQRT2)@|Square root of 2@|1.4142135623730951
     }

--- a/o.cyc
+++ b/o.cyc
@@ -548,6 +548,10 @@ Blah.
 
 See @link(|| infix operator) and @link(| infix operator).
 
+@specimen "Oracle Corporation"
+
+See @link(Eye of Sauron)
+
 @specimen "own property"
 
 An own property is a property of an object that is not inherited from another object. Properties that are directly assigned to an object are always own properties. The hasOwnProperty Object prototype function can be used to determine if an object has an own property with a given key.

--- a/x.cyc
+++ b/x.cyc
@@ -1,9 +1,5 @@
 @chapter "X"
 
-@specimen "x"
-
-    Blah. See @link 'hexadecimal'.
-
 @specimen "XML"
 
     XML @aka 'Extensible Markup Language' is a document format based on SGML.

--- a/y.cyc
+++ b/y.cyc
@@ -1,11 +1,5 @@
 @chapter "Y"
 
-@specimen "y"
-
-    @article "@t(y) @link 'regexp flag'"
-
-    (Blah.)
-
 @specimen "y combinator"
 
     Blah.


### PR DESCRIPTION
Fixed the ECMA entries in E.cyc, and if there is a need to highlight features added in each version. They can easily be added in their respective specimens.  I removed the individual entries for Regexp flags as they should be organized into a nice table in the article. 